### PR TITLE
Add -rpcallowip=0.0.0.0/0 & -rpcbind=0.0.0.0 to default configuration

### DIFF
--- a/electrumsv_node/electrumsv_node.py
+++ b/electrumsv_node/electrumsv_node.py
@@ -101,7 +101,9 @@ def shell_command(config_path: Optional[str] = None, data_path: Optional[str] = 
         f"-preload=1",
         f"-rejectmempoolrequest=0",
         f"-whitelist=127.0.0.1",
-        f"-debug=1"
+        f"-debug=1",
+        f"-rpcallowip=0.0.0.0/0",
+        f"-rpcbind=0.0.0.0"
     ])
     if extra_params is not None:
         split_command.extend(extra_params)


### PR DESCRIPTION
- This makes the node RPC and REST api reachable from host to docker